### PR TITLE
Change the chat sound for pause messages

### DIFF
--- a/lua/nsl_mainplugin_client.lua
+++ b/lua/nsl_mainplugin_client.lua
@@ -27,6 +27,7 @@ local kNSLMaterial = PrecacheAsset("materials/teamlogos/teamlogos.material")
 local kNSLTeamDecals = PrecacheAsset("materials/teamlogos/logos.dds")
 local kNSLTeamConfig = { }
 local kTeamWinScreensEnabled = false
+local kNSLChatSoundWarning = PrecacheAsset("sound/NS2.fev/common/invalid")
 
 local function OnNewTeamNames(message)
 	kTeam1NameLocal = message.team1name
@@ -102,7 +103,11 @@ local function AdminMessageRecieved(message)
         table.insert(chatMessages, 0)
         table.insert(chatMessages, 0)
 
-        StartSoundEffect(player:GetChatSound())
+        if message.changesound then 
+            StartSoundEffect(kNSLChatSoundWarning)
+        else
+            StartSoundEffect(player:GetChatSound())
+        end
 		Shared.Message(message.header .. " " .. message.message)
         
 	end

--- a/lua/nsl_mainplugin_server.lua
+++ b/lua/nsl_mainplugin_server.lua
@@ -155,7 +155,7 @@ ReplaceLocals(NS2Gamerules.OnUpdate, { ServerAgeCheck = NewServerAgeCheck })
 kFriendlyFireScalar = GetNSLConfigValue("FriendlyFireDamagePercentage")
 
 --Simple functions to make sending messages easier.
-local function BuildAdminMessage(message, teamname, client)
+local function BuildAdminMessage(message, teamname, client, changesound)
 	local t = { }
 	local mod
 	t.message = string.sub(message, 1, 250)
@@ -169,11 +169,12 @@ local function BuildAdminMessage(message, teamname, client)
 	end
 	t.header = string.format(mod and "(%s)(%s):" or "(%s):", GetNSLConfigValue("LeagueName"), mod)
 	t.color = GetNSLConfigValue("MessageColor")
+    t.changesound = changesound
 	return t
 end
 
-function SendAllClientsMessage(message)
-	Server.SendNetworkMessage("NSLSystemMessage", BuildAdminMessage(message), true)
+function SendAllClientsMessage(message, changesound)
+	Server.SendNetworkMessage("NSLSystemMessage", BuildAdminMessage(message, nil, nil, changesound), true)
 end
 
 function SendClientMessage(client, message)

--- a/lua/nsl_mainplugin_shared.lua
+++ b/lua/nsl_mainplugin_shared.lua
@@ -28,6 +28,7 @@ local kAdminChatMessage =
 	header = string.format("string (%d)", kMaxAdminChatLength + 1),
     message = string.format("string (%d)", kMaxAdminChatLength + 1),
 	color = string.format("string (%d)", 7),
+	changesound = "boolean" -- bool for now. later maybe filenames, or ints and keep an index somewhere
 }
 
 Shared.RegisterNetworkMessage("NSLSystemMessage", kAdminChatMessage)

--- a/lua/nsl_pause_server.lua
+++ b/lua/nsl_pause_server.lua
@@ -387,7 +387,7 @@ local function UpdateMoveState(deltatime)
 					SendAllClientsMessage(GetNSLMessage("PauseNoTeamReadyMessage"))
 				end
 				if GetNSLConfigValue("PausedMaxDuration") ~= 0 then
-					SendAllClientsMessage(string.format(GetNSLMessage("PauseResumeWarningMessage"), ((GetNSLConfigValue("PausedMaxDuration") - gamestate.gamepauseddelta))))
+					SendAllClientsMessage(string.format(GetNSLMessage("PauseResumeWarningMessage"), ((GetNSLConfigValue("PausedMaxDuration") - gamestate.gamepauseddelta))), true)
 				end
 				gamestate.gamepausedmessagetime = 0
 			end
@@ -414,7 +414,7 @@ local function UpdateMoveState(deltatime)
 		if gamestate.gameprepausedelta >= 1 then
 			gamestate.gamepausedcountdown = (gamestate.gamepausedcountdown - 1)
 			if gamestate.gamepausedcountdown > 0 then
-				SendAllClientsMessage(string.format(GetNSLMessage("PauseWarningMessage"), ConditionalValue(GetIsGamePaused(), "resume", "pause"), (gamestate.gamepausedcountdown)))
+				SendAllClientsMessage(string.format(GetNSLMessage("PauseWarningMessage"), ConditionalValue(GetIsGamePaused(), "resume", "pause"), (gamestate.gamepausedcountdown)), true)
 			else
 				if not GetIsGamePaused() then
 					SaveEntStates()
@@ -454,7 +454,7 @@ local function OnCommandPause(client)
 					gamestate.gamepausedcountdown = GetNSLConfigValue("PauseStartDelay")
 					gamestate.gamepausingteam = teamnumber
 					gamestate.serverprepauseloopenabled = true
-					SendAllClientsMessage(string.format(GetNSLMessage("PausePlayerMessage"), player:GetName()))
+					SendAllClientsMessage(string.format(GetNSLMessage("PausePlayerMessage"), player:GetName()), true)
 				else
 					SendClientMessage(client, GetNSLMessage("PauseTooManyPausesMessage"))
 				end


### PR DESCRIPTION
Adds a boolean to NSLSystemMessage. When true, clients play
kNSLChatSoundWarning instead of the normal chat sound. This bool
is enabled for pause messages.

I didn't look too hard for a good sound, there might be better ones. 
Hopefully it should be easy to change the new netvar to a string or int,
and have custom sounds for anything; for now this is enough.