### PR TITLE
Give NSL admins access to the Shine versions of vanilla commands

### DIFF
--- a/configs/nsl_leagueconfig.json
+++ b/configs/nsl_leagueconfig.json
@@ -61,7 +61,11 @@
 														[
 															"sv_kick", 
 															"sv_say", 
-															"sv_changemap"
+															"sv_changemap",
+															"sh_adminmenu",
+															"sh_kick",
+															"sh_say",
+															"sh_changelevel"
 														],
 														"type": "allowed"
 													},
@@ -78,14 +82,25 @@
 															"sv_rrall", 
 															"sv_eject", 
 															"sv_tsay", 
-															"sv_psay"
+															"sv_psay",
+															"sh_adminmenu",
+															"sh_ban",
+															"sh_unban",
+															"sh_kick",
+															"sh_say",
+															"sh_changelevel",
+															"sh_reset",
+															"sh_setteam",
+															"sh_rr",
+															"sh_eject"
 														],
 														"type": "allowed"
 													},
 													"4":{
 														"commands": 
 														[
-															"sv_rcon"
+															"sv_rcon",
+															"sh_rcon"
 														],
 														"type": "disallowed"
 													}		

--- a/lua/nsl_configs_server.lua
+++ b/lua/nsl_configs_server.lua
@@ -415,6 +415,31 @@ function GetClientCanRunCommand(client, commandName, printWarning)
 	
 end
 
+local Shine = Shine
+
+if Shine then
+    -- Adds the graphical AdminMenu button to Shine's VoteMenu
+    -- for NSL admins who can use sh_adminmenu
+    local oldHasAccess = Shine.HasAccess
+    function Shine:HasAccess(client, commandName)
+        local ns2id = client:GetUserId()
+        local oldAccess = oldHasAccess(self, client, commandName)
+        local newAccess = GetCanRunCommandviaNSL(ns2id, commandName)
+
+        return oldAccess or newAccess
+    end
+
+    -- Gives NSL admins access to their group's Shine commands
+    local oldGetPermission = Shine.GetPermission
+    function Shine:GetPermission(client, commandName)
+        local ns2id = client:GetUserId()
+        local oldPerm = oldGetPermission(self, client, commandName)
+        local newPerm = GetCanRunCommandviaNSL(ns2id, commandName)
+
+        return oldPerm or newPerm
+    end
+end
+
 local Messages = {
 PauseResumeMessage 					= "Game Resumed.  %s have %s pauses remaining",
 PausePausedMessage					= "Game Paused.",


### PR DESCRIPTION
Adds a list of Shine commands to the NSL league config.
Changes two Shine functions, GetPermission and HasAccess, to account for NSL permissions.

I considered putting the new commands and functions into a separate file (maybe called `lua/nsl_shineplugin_server.lua`) for readability, but since I added so little code, I figure config stuff goes with config stuff.