### PR TITLE
Automatically cycle the map when a map change fails

### DIFF
--- a/lua/nsl_mainplugin_server.lua
+++ b/lua/nsl_mainplugin_server.lua
@@ -136,6 +136,15 @@ function MapCycle_CycleMap()
 	--Override to prevent automatic mapcycle from lazy server admins
 end
 
+--Keep vanilla behavior when a map change fails
+local function OnMapChangeFailed(mapName)
+    Log("Failed to load map '%s', cycling...", mapName);
+    oldMapCycle_CycleMap(mapName)
+end
+
+Event.RemoveHook("MapChangeFailed")
+Event.Hook("MapChangeFailed", OnMapChangeFailed)
+
 local function NewServerAgeCheck(self)
 	if GetNSLModEnabled() then
 		if self.gameState ~= kGameState.Started and Shared.GetTime() > GetNSLConfigValue("AutomaticMapCycleDelay") and Server.GetNumPlayers() == 0 then


### PR DESCRIPTION
Previously, a failed map change (e.g. because the map was
mis-spelled) would hang the server. Now NSL mod performs
the vanilla behavior and cycles to another map.

Maybe there is some fancier way of doing this just within the 
new MapCycle_CycleMap, by only calling the old version 
if the calling function is OnMapChangedFailed (which vanilla 
hooks to a failed map change). But that's beyond me.
