### PR TITLE
Fix handling of the various arguments to Shine's functions

### DIFF
--- a/lua/nsl_configs_server.lua
+++ b/lua/nsl_configs_server.lua
@@ -422,7 +422,9 @@ if Shine then
     -- for NSL admins who can use sh_adminmenu
     local oldHasAccess = Shine.HasAccess
     function Shine:HasAccess(client, commandName)
-        local ns2id = client:GetUserId()
+        if not client then return true end
+
+        local _, ns2id = Shine:GetUserData(client)
         local oldAccess = oldHasAccess(self, client, commandName)
         local newAccess = GetCanRunCommandviaNSL(ns2id, commandName)
 
@@ -432,7 +434,9 @@ if Shine then
     -- Gives NSL admins access to their group's Shine commands
     local oldGetPermission = Shine.GetPermission
     function Shine:GetPermission(client, commandName)
-        local ns2id = client:GetUserId()
+        if not client then return true end
+
+        local _, ns2id = Shine:GetUserData(client)
         local oldPerm = oldGetPermission(self, client, commandName)
         local newPerm = GetCanRunCommandviaNSL(ns2id, commandName)
 


### PR DESCRIPTION
Shine.HasAccess and Shine.GetPermission can take either an NS2ID
or a Client as their first argument. Previously, we assumed it
would be a Client; we now handle both cases.

NS2ID is used in this way exactly once, in the Reserved Slots plugin,
and Shine handles the error by unloading the plugin (which nobody
cared enough to notice until I pointed it out to them). So a few servers
get some log spam, but this isn't game breaking.