### PR TITLE
Properly remove vanilla's OnMapChangeFailed hook

### DIFF
--- a/lua/nsl_mainplugin_server.lua
+++ b/lua/nsl_mainplugin_server.lua
@@ -137,13 +137,13 @@ function MapCycle_CycleMap()
 end
 
 --Keep vanilla behavior when a map change fails
-local function OnMapChangeFailed(mapName)
+local function NewOnMapChangeFailed(mapName)
     Log("Failed to load map '%s', cycling...", mapName);
     oldMapCycle_CycleMap(mapName)
 end
 
-Event.RemoveHook("MapChangeFailed")
-Event.Hook("MapChangeFailed", OnMapChangeFailed)
+Event.RemoveHook("MapChangeFailed", OnMapChangeFailed)
+Event.Hook("MapChangeFailed", NewOnMapChangeFailed)
 
 local function NewServerAgeCheck(self)
 	if GetNSLModEnabled() then


### PR DESCRIPTION
RemoveHook takes two arguments, so our previous usage of it did nothing.
This left vanilla's non-functional hook active. This had no adverse
consequences, but why leave a hook whose function we're replacing?

This is not urgent.