### PR TITLE
Enable all features of warmup mode except player damage

### DIFF
--- a/lua/nsl_mainplugin_server.lua
+++ b/lua/nsl_mainplugin_server.lua
@@ -118,17 +118,19 @@ originalNS2GRGetFriendlyFire = Class_ReplaceMethod("NS2Gamerules", "GetFriendlyF
 	end
 )
 
-local originalNS2GRGetWarmUpPlayerLimit
---Override warmup mode
-originalNS2GRGetWarmUpPlayerLimit = Class_ReplaceMethod("NS2Gamerules", "GetWarmUpPlayerLimit", 
-	function(self)
-		return GetNSLModEnabled() and 0 or originalNS2GRGetWarmUpPlayerLimit(self)
-	end
-)
-
 --Override friendly fire function checks
 function GetFriendlyFire()
 	return GetNSLConfigValue("FriendlyFireEnabled") and GetNSLModEnabled()
+end
+
+-- Prevent damage from players in warmup mode
+local oldCanEntityDoDamageTo = CanEntityDoDamageTo
+function CanEntityDoDamageTo(attacker, target, cheats, devMode, friendlyFire, damageType)
+	if GetNSLModEnabled() and GetGameInfoEntity():GetState() == kGameState.WarmUp then
+		return false
+	end
+
+	return oldCanEntityDoDamageTo(attacker, target, cheats, devMode, friendlyFire, damageType)
 end
 
 local oldMapCycle_CycleMap = MapCycle_CycleMap

--- a/lua/nsl_tournamentmode_server.lua
+++ b/lua/nsl_tournamentmode_server.lua
@@ -101,7 +101,7 @@ originalNS2GameRulesOnCommanderLogout = Class_ReplaceMethod("NS2Gamerules", "OnC
 		originalNS2GameRulesOnCommanderLogout(self, commandStructure, oldCommander)
 		if oldCommander and GetNSLModEnabled() then
 			local teamnum = oldCommander:GetTeamNumber()
-			if TournamentModeSettings[teamnum].ready and (GetGamerules():GetGameState() == kGameState.NotStarted or GetGamerules():GetGameState() == kGameState.PreGame) then
+			if TournamentModeSettings[teamnum].ready and (GetGamerules():GetGameState() <= kGameState.PreGame) then
 				TournamentModeSettings[teamnum].ready = false
 				CheckCancelGameStart()
 				SendTeamMessage(teamnum, GetNSLMessage("TournamentModeReadyNoComm"))
@@ -175,7 +175,7 @@ end
 local originalNS2GamerulesUpdatePregame
 originalNS2GamerulesUpdatePregame = Class_ReplaceMethod("NS2Gamerules", "UpdatePregame", 
 	function(self, timePassed)
-		if (self:GetGameState() == kGameState.PreGame or self:GetGameState() == kGameState.NotStarted) and not self.teamsReady and GetNSLModEnabled() then
+		if self:GetGameState() <= kGameState.PreGame and not self.teamsReady and GetNSLModEnabled() then
 			MonitorCountDown()
 		else
 			originalNS2GamerulesUpdatePregame(self, timePassed)
@@ -278,7 +278,7 @@ end
 local function OnCommandReady(client)
 	local gamerules = GetGamerules()
 	if gamerules and client and GetNSLModEnabled() then
-		if gamerules:GetGameState() == kGameState.NotStarted or gamerules:GetGameState() == kGameState.PreGame then
+		if gamerules:GetGameState() <= kGameState.PreGame then
 			ClientReady(client)
 		else
 			CheckforInProgressGameToCancel(client, gamerules)
@@ -310,7 +310,7 @@ end
 local function OnCommandNotReady(client)
 	local gamerules = GetGamerules()
 	if gamerules and client and GetNSLModEnabled() then
-		if gamerules:GetGameState() == kGameState.NotStarted or gamerules:GetGameState() == kGameState.PreGame then
+		if gamerules:GetGameState() <= kGameState.PreGame then
 			ClientNotReady(client)
 		else
 			CheckforInProgressGameToCancel(client, gamerules)


### PR DESCRIPTION
A few people requested this. Personally I'm not sure whether
it should be included, but it probably can't hurt. 

Warmup mode will be active when vanilla says it should be.
NSL's warmup mode is the same as vanilla's, except players
cannot deal damage. The infestation inside/around gorge
tunnels still deals damage to players/structures because
I'm lazy.

As in vanilla warmup, players can: buy guns and equipment;
evolve upgrades and lifeforms; drop gorge structures; use
gorge tunnels. Warmup is active until 12 players have joined
teams.

The only way to know when warmup ends/starts is that your 
crosshair disappears/appears. Buildings, equipment, and 
evolutions remain. It's not super great but vanilla doesn't
do a good job with it either.