### PR TITLE
Fixed perf rates not being set if perflevel is set to "default"

### DIFF
--- a/lua/nsl_mainplugin_server.lua
+++ b/lua/nsl_mainplugin_server.lua
@@ -5,11 +5,8 @@
 
 --NSL Main Plugin
 --Reworked to function more as a 'league' plugin, not just a ENSL plugin.
-local kCachedDataRate = 50
-local kCachedMoveRate = 30
-local kCachedInterp = 100
-local kCachedSendRate = 20
-local kCachedTickRate = 30
+local kCachedDataRate, kCachedMoveRate, kCachedInterp, kCachedSendRate
+local kCachedTickRate = Server.GetTickrate()
 local kNSLTag = "nsl"
 
 --Supposedly this still not syncronized.


### PR DESCRIPTION
The bug:
To see if we need to change any rates, we check if the perf config
rates are different than the cached rates. Previously, the cache
was pre-seeded with the default level's rates. This meant that if
the perf level was set to "Default", the actual rates were never
checked and so weren't changed.

The fix:
This commit removes the initial cache values for all rates except
the tickrate. The tickrate is used in a comparison, so we cache
that with the current server tickrate. 

You could maybe get the current value of each rate and seed the
cache with those, but I didn't see the point of bothering.